### PR TITLE
Add GH->Notion scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,15 @@ This contains two main classes:
 
 `NotionDatabase`: Defines a Notion database, along wih its properties and a remotely tied Notion client used for CRUD operations.
 `NotionProperty`: Defines a generic Notion property, including functions to return the right data for updating content and the property itself.
+
+## Github Issues -> Notion Pages
+
+There is a [shared GH database](https://www.notion.so/mzthunderbird/3030fbc779254c6bbbb76d391e2f7923?v=c81686996f5d4b0f8ff6a5ae3e5af309) across our repos. Each repository will have a page associated with it, whose parent page is the shared GH database. Each issue in a repostiory will be a notion task (a page), and these tasks' parent pages are their respective repository pages.
+
+actually, i'll just shove them on this page and add a column for the repo. It's less coding and we can just filter on it?
+
+Regarding the code:
+
+`gh_notion_sync.py` contains the list of repositories we will be combing, and triggers the import.
+`libs/ghhelper.py` contains helper functions for pulling in issues from Github and turning them into pages. 
+

--- a/gh_notion_sync.py
+++ b/gh_notion_sync.py
@@ -16,7 +16,8 @@ import pdb
 print('connecting to notion');
 database_id = "3030fbc779254c6bbbb76d391e2f7923"
 notion = Client(auth=os.environ['NOTION_TOKEN'])
-notion_db = NotionDatabase(database_id, notion, settings.properties)
+pdb.set_trace()
+notion_db = NotionDatabase(database_id, notion, settings.gh_properties)
 
 # Ensure the database has the properties we expect.
 # This should probably happen on init, but we'll do it explicitly for now.

--- a/gh_notion_sync.py
+++ b/gh_notion_sync.py
@@ -1,0 +1,26 @@
+"""
+import dateutil.parser
+import requests
+import time
+from datetime import datetime, timedelta
+"""
+import libs.ghhelper as ghhelper 
+from notion_client import Client
+from libs.notion_data import NotionDatabase
+import settings
+import os
+import pdb
+
+# Initialize the Notion client with your integration token
+#database_id = "c008270018c444fcb377170185c059ed"
+print('connecting to notion');
+database_id = "3030fbc779254c6bbbb76d391e2f7923"
+notion = Client(auth=os.environ['NOTION_TOKEN'])
+notion_db = NotionDatabase(database_id, notion, settings.properties)
+
+# Ensure the database has the properties we expect.
+# This should probably happen on init, but we'll do it explicitly for now.
+notion_db.update_props()
+#notion_db.get_all_pages();
+
+ghhelper.sync_gh_to_notion('thunderbird/appointment', os.environ['GITHUB_TOKEN'], notion_db)

--- a/gh_notion_sync.py
+++ b/gh_notion_sync.py
@@ -11,17 +11,22 @@ import settings
 import os
 import pdb
 
-# Initialize the Notion client with your integration token
-#database_id = "c008270018c444fcb377170185c059ed"
-print('connecting to notion');
-database_id = "3030fbc779254c6bbbb76d391e2f7923"
-notion = Client(auth=os.environ['NOTION_TOKEN'])
-pdb.set_trace()
-notion_db = NotionDatabase(database_id, notion, settings.gh_properties)
 
-# Ensure the database has the properties we expect.
-# This should probably happen on init, but we'll do it explicitly for now.
-notion_db.update_props()
-#notion_db.get_all_pages();
+# To add more repos, duplicate an existing notion page that uses this script, ex: https://www.notion.so/mzthunderbird/11b2df5d45ae80dcb716c22f068ce667?v=11b2df5d45ae81fda446000c779bfb51
+# Then add the MZLA Integration connection so we can access it through the API. Then add the repo name database id below:
+repos = [
+    ["thunderbird/pulumi", "11b2df5d45ae80dcb716c22f068ce667"],
+    ["thunderbird/assist-daily-digest", "11b2df5d45ae80e0b3a9d275b8e58f30"],
+    ["thunderbird/send-suite", "11b2df5d45ae80c5a078e5f041dfe06d"],
+    ["thunderbird/appointment", "3030fbc779254c6bbbb76d391e2f7923"],
+]
 
-ghhelper.sync_gh_to_notion('thunderbird/appointment', os.environ['GITHUB_TOKEN'], notion_db)
+for repo in repos:
+    repo_name = repo[0]
+    database_id = repo[1]
+    print('connecting to notion for ', repo_name);
+    # Initialize the Notion client with your integration token
+    notion = Client(auth=os.environ['NOTION_TOKEN'])
+
+    notion_db = NotionDatabase(database_id, notion, settings.gh_properties)
+    ghhelper.sync_gh_to_notion([repo_name], os.environ['GITHUB_TOKEN'], notion_db, database_id)

--- a/libs/ghhelper.py
+++ b/libs/ghhelper.py
@@ -1,0 +1,133 @@
+import requests
+import settings
+import time
+import os
+
+from datetime import datetime, timedelta
+from typing import Dict, Any
+
+from .notion_data import NotionDatabase
+from github import Auth
+from github import Github
+import pdb
+
+
+PROJECT_PHASE_PREFIX = "phase:"
+
+def issue_status_to_notion(issue):
+    """Convert a GH state to values suitable for Notion."""
+    # TODO
+    return issue.state
+
+def map_issue_to_page(issue):
+    """Mapping for issue fields to Notion properties. """
+    notion_data = {
+        'Bug Status': issue.state,
+        'Assignee': issue.assignee if issue.assignee else '',
+        'Bug Number': issue.number,
+        'Link': issue.url,
+        'Summary': issue.title
+        #'Labels': 
+    }
+    for label in issue.get_labels():
+        label_name = label.name
+        if label_name.startswith(PROJECT_PHASE_PREFIX):
+            print("got phase: ", label_name);
+            notion_data['Phase']: label_name[len(PROJECT_PHASE_PREFIX):].strip()
+    return notion_data
+
+def page_data(issue, notion_db):
+    """Converts `issue` into a dict that matches the formatting for a Notion db page."""
+    issue_data = map_issue_to_page(issue)
+    props = notion_db.properties
+
+    page = {
+        "Status": {"status": {"name": issue_data.pop('Bug Status')}},
+        "Summary": {"type": "title", "title": [{"text": {"content": issue_data.pop('Summary')}}]}
+    }
+
+    for key, value in issue_data.items():
+        if key in props:
+            page.update(props[key].update_content(value))
+
+    return page
+
+def get_all_issues(repo: str, gh_api_key: str, status: str = 'open') -> Dict[str, Any]:
+    """Get all issues from repo """
+    token = os.environ['GITHUB_TOKEN']
+    auth = Auth.Token(token)
+    g = Github(auth=auth)
+    repo = g.get_repo('thunderbird/appointment')
+    issues = repo.get_issues(state=status)
+    g.close()
+    return issues
+
+
+def issue_page_diff(issue: Dict[str, Any], page: Dict[str, Any], notion_db: NotionDatabase) -> bool:
+    """Return true or false based on whether the Notion `page` matches the issue data or not."""
+    props = notion_db.properties
+
+    for prop_name, isue_value in map_issue_to_page(issue).items():
+        if prop_name in props and props[prop_name].is_prop_diff(page["properties"].get(prop_name, {}), issue_value):
+            return True
+
+    return False
+
+
+def update_page(issue, page, notion_db):
+    """Helper to update a page in Notion based on issue data."""
+    # Only update if data is different.
+    if issue_page_diff(issue, page, notion_db):
+        data = page_data(issue, notion_db)
+        if notion_db.update_page(page["id"], data):
+            return True
+    return False
+
+
+def create_page(issue, notion_db):
+    """Helper to create a new page in Notion based on issue data."""
+    new_page = page_data(issue, notion_db)
+    pdb.set_trace();
+    if notion_db.create_page(new_page):
+        return True
+    else:
+        return False
+
+
+def sync_gh_to_notion(repo, gh_api_key, notion_db):
+    issues = get_all_issues(repo, gh_api_key)
+    print('retrieved: ', issues);
+    pages = notion_db.get_all_pages()
+    issue_count = issues.totalCount
+    # dict of issues numbers: pages for issues in the notion db
+    pages_issues = {p["properties"]["Bug Number"]["number"]:p for p in pages}
+    issue_ids = [issue.number for issue in issues]
+
+    added = 0
+    updated = 0
+    deleted = 0
+
+    # delete pages that no longer match the criteria to be included
+    for inum in pages_issues.keys():
+        if inum and inum not in issue_ids:
+            notion_db.delete_page(pages_issues[inum]["id"])
+            print('deleting: ', inum)
+            deleted += 1
+
+    # Add or update pages corresponding to issue.
+    for issue in issues:
+        # Sleep for a bit if we're hammering the Notion API.
+        total_changes = added + updated
+        if total_changes > 0 and total_changes % 20 == 0:
+            print(f"Added {added} issues, updated {updated}, and deleted {deleted}")
+            print("Sleeping for 10 seconds...")
+            time.sleep(10)
+
+        elif "id" in pages_issues.keys():
+            if update_page(issue, pages_issues[issue["id"]], notion_db):
+                updated += 1
+        else:
+            if create_page(issue, notion_db):
+                added += 1
+    print(len(pages))
+    print(f"Sync Complete. {issue_count} issues in query, {pagecount} in Notion: Added {added}, updated {updated}, and deleted {deleted}")

--- a/libs/ghhelper.py
+++ b/libs/ghhelper.py
@@ -23,17 +23,18 @@ def map_issue_to_page(issue):
     """Mapping for issue fields to Notion properties. """
     notion_data = {
         'Bug Status': issue.state,
-        'Assignee': issue.assignee if issue.assignee else '',
+        'Assignee': issue.assignee.login if issue.assignee else 'None',
         'Bug Number': issue.number,
-        'Link': issue.url,
+        'Link': issue.html_url,
         'Summary': issue.title
         #'Labels': 
     }
+    notion_data['Phase'] = ''
     for label in issue.get_labels():
         label_name = label.name
         if label_name.startswith(PROJECT_PHASE_PREFIX):
             print("got phase: ", label_name);
-            notion_data['Phase']: label_name[len(PROJECT_PHASE_PREFIX):].strip()
+            notion_data['Phase'] = label_name[len(PROJECT_PHASE_PREFIX):].strip()
     return notion_data
 
 def page_data(issue, notion_db):
@@ -42,7 +43,7 @@ def page_data(issue, notion_db):
     props = notion_db.properties
 
     page = {
-        "Status": {"status": {"name": issue_data.pop('Bug Status')}},
+        #"Status": {"status": {"name": issue_data.pop('Bug Status')}},
         "Summary": {"type": "title", "title": [{"text": {"content": issue_data.pop('Summary')}}]}
     }
 
@@ -87,7 +88,6 @@ def update_page(issue, page, notion_db):
 def create_page(issue, notion_db):
     """Helper to create a new page in Notion based on issue data."""
     new_page = page_data(issue, notion_db)
-    pdb.set_trace();
     if notion_db.create_page(new_page):
         return True
     else:

--- a/libs/notion_data.py
+++ b/libs/notion_data.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Callable
 
+import pdb
+
 @dataclass
 class NotionProperty:
     """
@@ -55,7 +57,6 @@ class NotionDatabase:
         while True:
             response = self.notion.databases.query(
                 self.database_id,
-                filter=None,
                 start_cursor=cursor,
                 page_size=100
             )
@@ -97,11 +98,13 @@ class NotionDatabase:
     def update_props(self):
         """Updates the properties of the remote Notion database tied to the local instance."""
         # TODO: This method could use some error checking and verifying that it worked properly.
+        print('in update props');
         desired_props = self.to_dict()
 
         # Fetch the current properties of the database
         current_db = self.notion.databases.retrieve(database_id=self.database_id)
         current_props = current_db["properties"]
+        print(current_props);
 
         # Process current properties: rename title, delete others not in desired list, and add/update missing properties
         for prop_name, prop_info in current_props.items():

--- a/libs/notion_data.py
+++ b/libs/notion_data.py
@@ -98,13 +98,11 @@ class NotionDatabase:
     def update_props(self):
         """Updates the properties of the remote Notion database tied to the local instance."""
         # TODO: This method could use some error checking and verifying that it worked properly.
-        print('in update props');
         desired_props = self.to_dict()
 
         # Fetch the current properties of the database
         current_db = self.notion.databases.retrieve(database_id=self.database_id)
         current_props = current_db["properties"]
-        print(current_props);
 
         # Process current properties: rename title, delete others not in desired list, and add/update missing properties
         for prop_name, prop_info in current_props.items():

--- a/settings.py
+++ b/settings.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass, field
 from libs.notion_data import link, select, number, rich_text
 from typing import Dict, Any
-import copy
 
 bugzilla_base_url = "https://bugzilla.mozilla.org"
 

--- a/settings.py
+++ b/settings.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from libs.notion_data import link, select, number, rich_text
 from typing import Dict, Any
+import copy
 
 bugzilla_base_url = "https://bugzilla.mozilla.org"
 
@@ -40,4 +41,12 @@ properties = [
     select('Product', ['Thunderbird', 'MailNews Core', 'Calendar']),
     rich_text('Version'),
     rich_text('Whiteboard')
+]
+
+gh_properties = [
+    rich_text('Assignee'),
+    number('Bug Number'),
+    link('Link'),
+    rich_text('Phase'),
+    rich_text('Bug Status')
 ]


### PR DESCRIPTION
I'd like to merge this now, since RyanJ may be amending some of this code in the future and I'd like to avoid "branches of a branch" situation. I also wanna hook this up to a machine to run daily, so we may as well put this in main.

This script is working to produce one Notion page per repo. There is some dead code in the ghhelper.py file, and I'll address that in an upcoming PR