### PR TITLE
Set Status from GH if it is Closed or Re-opened, otherwise, keep Notion status

### DIFF
--- a/libs/ghhelper.py
+++ b/libs/ghhelper.py
@@ -9,7 +9,7 @@ from sgqlc.operation import Operation
 from sgqlc_schemas import github_schema as schema
 from typing import Dict, Any
 
-def map_issue_to_page(issue, milestones, page_status):
+def map_issue_to_page(issue, milestones, page_status=None):
     """Map a single issue's data into the datadict format for the NotionDatabase class. """
     notion_data = {
         'Assignee': ' '.join(a.login for a in issue.assignees.nodes) if issue.assignees.nodes else '',

--- a/libs/ghhelper.py
+++ b/libs/ghhelper.py
@@ -9,23 +9,9 @@ from sgqlc.operation import Operation
 from sgqlc_schemas import github_schema as schema
 from typing import Dict, Any
 
-def issue_status_to_notion(issue) -> str:
-    """Convert a GH issue state to a Notion database status."""
-    if issue.state == "CLOSED":
-        status = "Done"
-    elif issue.state == "OPEN":
-        if issue.assignees.nodes:
-            status = "In progress"
-        else:
-            status = "Not started"
-
-    return status
-
-
 def map_issue_to_page(issue, milestones):
     """Map a single issue's data into the datadict format for the NotionDatabase class. """
     notion_data = {
-        'Status': issue_status_to_notion(issue),
         'Assignee': ' '.join(a.login for a in issue.assignees.nodes) if issue.assignees.nodes else '',
         'Link': issue.url,
         'Title': issue.title,
@@ -35,6 +21,9 @@ def map_issue_to_page(issue, milestones):
         'Closed': issue.closed_at,
         'Labels': [l.name for l in issue.labels.nodes],
     }
+
+    if issue.state == "CLOSED":
+        notion_data['Status'] = "Done"
 
     filtered_labels = [label[2:].strip() for label in notion_data['Labels'] if label.startswith("M:") and label[2:].strip() in milestones]
     notion_data['Milestones'] = [milestones[label] for label in filtered_labels]

--- a/libs/notion_data.py
+++ b/libs/notion_data.py
@@ -97,10 +97,12 @@ class NotionDatabase:
         A datadict is a dictionary containing {<property_name>: <data>}.
         """
         props = self.properties
+        page = {}
 
-        page = {
-            "Status": {"status": {"name": datadict.pop('Status')}}
-        }
+        if datadict.get('Status'):
+            page = {
+                "Status": {"status": {"name": datadict.pop('Status')}}
+            }
 
         for key, value in datadict.items():
             if key in props:


### PR DESCRIPTION
We'll be managing the workflow of a ticket through Notion's status, so we need to avoid overwriting Notion's status with anything from GH other than new tickets or re-opened ones.

I've tested this against https://www.notion.so/mzthunderbird/1422df5d45ae806f8befef10db3a6f5d?v=1422df5d45ae81399169000c867bce7a with 'cloudops', by closing and opening a ticket, and by setting "In progress" to some tickets and ensuring that the status persists.