### PR TITLE
Add 3 repos that are used for reporting

### DIFF
--- a/config/sync_settings.production.toml
+++ b/config/sync_settings.production.toml
@@ -91,6 +91,9 @@ tasks_body_sync = false
 [sync.support.repositories]
 repositories = [
     "thunderbird/knowledgebase-issues",
+    "thunderbird/github-action-tbandroid-aaq",
+    "thunderbird/github-action-thunderbird-aaq",
+    "thunderbird/thunderbird-metrics-and-reports"
 ]
 
 [sync.support.properties]


### PR DESCRIPTION
gitthub-action-tbandroid-aaq gets all the SUMO forum questions for Android, github-action-thunderbird-aaq gets all the SUMO forum questions for Desktop. Both github actions are read by the reports repo