### PR TITLE
Add milestones_allow_parents to preserve sub-issue hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ milestones_body_sync = false
 # will be updated with the markdown.
 milestones_body_sync_if_empty = true
 
+# By default, GitHub issues with the configured milestones_issue_type are required to be top-level
+# (no parent). The sync will remove any parent link it finds on such issues. Set this to true to
+# preserve parent links on milestone-typed issues — useful when your repos already model a
+# multi-level hierarchy (e.g. Epic -> Milestone -> Task) using GitHub sub-issues. Default: false.
+milestones_allow_parents = false
+
 # If you want all GitHub issues connected to milestones to have a prefix in their title, set this
 # property. Don't forget the trailing space.
 milestones_github_prefix = "[EPIC] "

--- a/mzla_notion/cli.py
+++ b/mzla_notion/cli.py
@@ -154,6 +154,7 @@ async def cmd_synchronize(projects, config, verbose=0, dry_run=False, synchronou
                     dry=dry_run or project.get("tracker_dry_run", False),
                     user_map=user_map.get("github") or {},
                     milestones_issue_type=project.get("milestones_issue_type", None),
+                    milestones_allow_parents=project.get("milestones_allow_parents", False),
                     property_names=project.get("properties", {}),
                 )
 

--- a/mzla_notion/tracker/github.py
+++ b/mzla_notion/tracker/github.py
@@ -118,7 +118,15 @@ class GitHub(IssueTracker, GitHubFixups):
 
     name = "GitHub"
 
-    def __init__(self, token=None, repositories={}, user_map=None, milestones_issue_type=None, **kwargs):
+    def __init__(
+        self,
+        token=None,
+        repositories={},
+        user_map=None,
+        milestones_issue_type=None,
+        milestones_allow_parents=False,
+        **kwargs,
+    ):
         """Initialize issue tracker."""
         super().__init__(**kwargs)
 
@@ -132,6 +140,7 @@ class GitHub(IssueTracker, GitHubFixups):
         self.label_cache = LabelCache(self.endpoint)
         self.issue_planning_cache = IssuePlanningCache(self.endpoint)
         self.milestones_issue_type = milestones_issue_type
+        self.milestones_allow_parents = milestones_allow_parents
 
         self._init_repository_settings(repositories)
         self._raw_user_map = user_map

--- a/mzla_notion/tracker/github_fixups.py
+++ b/mzla_notion/tracker/github_fixups.py
@@ -119,12 +119,12 @@ class GitHubFixups:
         tasks_project_item, milestones_project_item = self._get_project_items(ghissue)
         issue_type = getnestedattr(lambda: ghissue.issue_type.name, None)
         orgrepo = ghissue.repository.name_with_owner
+        allow_parents = getattr(self, "milestones_allow_parents", False)
 
         if tasks_project_item and milestones_project_item:
             # Issues cannot be on both tasks and milestone projects
-            if not ghissue.parent and (
-                issue_type == self.milestones_issue_type or (sub_issues and ghissue.sub_issues.nodes)
-            ):
+            looks_like_milestone = issue_type == self.milestones_issue_type or (sub_issues and ghissue.sub_issues.nodes)
+            if (allow_parents or not ghissue.parent) and looks_like_milestone:
                 # This is a milestone, or it at least has sub-issues. Remove it from the task
                 # project
                 logger.warning(
@@ -167,6 +167,9 @@ class GitHubFixups:
 
     async def _fixup_issue_milestone_with_parent(self, ghissue):
         """Issues on the Milestone project shouldn't have parents. Avoids sub-issues landing on the roadmap."""
+        if getattr(self, "milestones_allow_parents", False):
+            return
+
         _, milestones_project_item = self._get_project_items(ghissue)
         orgrepo = ghissue.repository.name_with_owner
 


### PR DESCRIPTION
## Summary

Adds a per-sync `milestones_allow_parents` config option (default `false`) for the `github_project` sync method. When `true`, the sync stops trying to enforce that issues typed `milestones_issue_type` must be top-level — both relevant fixup branches in [mzla_notion/tracker/github_fixups.py](https://github.com/thunderbird/notion-scripts/blob/feat/milestones-allow-parents/mzla_notion/tracker/github_fixups.py) are short-circuited:

- `_fixup_issue_milestone_with_parent` no longer issues the GraphQL `removeSubIssue` mutation that strips parent links from milestone-typed issues, and no longer evicts such issues from the milestones board.
- `_fixup_issue_both_projects` keeps a milestone-typed issue on the milestones board when the same issue ends up on both boards, regardless of whether it has a parent.

Default behavior is unchanged.

## Why

The hierarchy (from [here](https://mozilla-hub.atlassian.net/wiki/spaces/MZLA/pages/2344976385/Process+Overview)) (top to bottom) is: Program → Epic → Milestone → Task → Sprint

Definitions:

1. **Epic** — a multi-month, multi-milestone container. Usually represents a point when work can be consumed by an audience ("alpha shippable"). Ceiling is 3 months when in doubt (some docs say up to 6).
1. **Milestone** — does not have to be user-visible or shippable on its own. Marks when a defined effort is complete: a migration, a deployment, a capability landing.
1. **Task** — single assignee, 1–2 sprints. Anything that can't fit in two sprints should be split.
1. **Sprint** — numbered by ISO week of year (Sprint 18 = week 18). Tasks can span multiple sprints; they're not strictly time-boxed to one.

If I have a GitHub repo that models a multi-level hierarchy (e.g. **Epic → Milestone → Task**), the current fixups treat any parent on a milestone-typed issue as a violation and silently rip the parent link out on every sync cycle. 

With this flag set on the affected sync, the GitHub hierarchy is preserved while Notion still gets the same Milestone + child-Task view it does today (the Epic layer remains GitHub-only / manually surfaced via Notion's existing Epic relation, like other teams already do).

Concretely this is needed for thunderbird/platform-infrastructure, which already uses GitHub sub-issues for the full Epic → Milestone → Task chain and would otherwise have its hierarchy flattened the first time the sync ran against it.

## Changes

- [mzla_notion/cli.py](https://github.com/thunderbird/notion-scripts/blob/feat/milestones-allow-parents/mzla_notion/cli.py): plumb the new option from `sync_settings.toml` through to `GitHub.create()`.
- [mzla_notion/tracker/github.py](https://github.com/thunderbird/notion-scripts/blob/feat/milestones-allow-parents/mzla_notion/tracker/github.py): accept the option in `GitHub.__init__` and store it on the tracker.
- [mzla_notion/tracker/github_fixups.py](https://github.com/thunderbird/notion-scripts/blob/feat/milestones-allow-parents/mzla_notion/tracker/github_fixups.py): early-return / relax discriminators when the flag is set.
- [README.md](https://github.com/thunderbird/notion-scripts/blob/feat/milestones-allow-parents/README.md): document the new option in the existing verbose `sync_settings.toml` example.

## Test plan

- [x] `uv run task lint` — passes
- [x] `uv run task format --check` — passes
- [x] `uv run task test` — 68/68 pass
- [ ] Manual dry-run against a repo with an `issue_type=Milestone` issue that has a parent, with the flag both unset and set to `true`, confirming the `removeSubIssue` mutation is only attempted when the flag is unset.
- [ ] No new unit-test coverage added for the fixup branches — the existing test suite has no fixup coverage to extend, and adding fixtures for the GraphQL mutation paths is a larger separate effort. Happy to follow up if reviewers want it bundled here.

## Notes

- Backwards compatible — flag defaults to `false`, preserving current behavior for all existing syncs (mobile, support, services, desktop).
- No upstream config (\`config/sync_settings.production.toml\`, \`config/sync_settings.dev.toml\`) is changed in this PR. Adoption for individual syncs is intentionally separate.

Opening as draft for review.