### PR TITLE
Add QA Log to Pull Request Template

### DIFF
--- a/templates/src/.github/PULL_REQUEST_TEMPLATE.md
+++ b/templates/src/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,6 +36,12 @@
   Using the "Closes #123" format will link pull request and issue.
 -->
 
+## QA Log
+
+<!--
+Bulleted list of any steps taken to validate correctness beyond automated tests.
+-->
+
 ## Screenshots
 
 <!--

--- a/templates/src/.github/PULL_REQUEST_TEMPLATE.md
+++ b/templates/src/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,6 +40,10 @@
 
 <!--
 Bulleted list of any steps taken to validate correctness beyond automated tests.
+
+For example:
+
+* manually tested sign-up workflow happy path in Firefox, Safari and Chrome on macOS
 -->
 
 ## Screenshots


### PR DESCRIPTION
Communicating testing details helps the reviewer to understand
what's been tested so far so they might either ask for additional
QA steps or focus their own review to avoid duplicate work.
