### PR TITLE
Ignore sub-sub-issues when syncing tasks to Notion

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,10 @@ Here is your workflow as a manager/project manager:
 
 Here is your workflow as an engineer:
 * Use the Epic issue on GitHub as the parent item for any work you do. All child issues one level
-  deep will be synchronized to Notion. 
+  deep will be synchronized to Notion. The sync only supports a single Milestone -> Task layer, so
+  sub-issues of a task (sub-sub-issues) are ignored on the Notion side. They stay intact on GitHub
+  for your own tracking, but won't appear as tasks in Notion. Promote a task to a Milestone if you
+  need its sub-issues to show up.
 * Plan these issues into sprints using the Sprints GitHub Project. You can do all the work on
   GitHub.
 * If you have additional high level tasks or are still breaking things down, you can also use Tasks

--- a/mzla_notion/sync/base.py
+++ b/mzla_notion/sync/base.py
@@ -493,6 +493,10 @@ class BaseSync:
             page (dict): The Notion page object of the existing task in notion. Leave out to add
                 instead of update.
         """
+        if tracker_issue.deeply_nested:
+            logger.info(f"Skipping nested task {tracker_issue.repo}#{tracker_issue.id} - {tracker_issue.title}")
+            return
+
         if page:
             old_issue_url = getnestedattr(
                 lambda: self._get_prop(page, "notion_issue_field", [])[0]["external"]["url"], None

--- a/mzla_notion/tracker/common.py
+++ b/mzla_notion/tracker/common.py
@@ -47,6 +47,9 @@ class Issue(IssueRef):
     sub_issues: list = field(default_factory=list)
     whiteboard: str = ""
     requested_ref: IssueRef = None
+    # True when the issue is nested deeper than a single sub-issue layer (a sub-issue of a task).
+    # The sync only supports a Milestone -> Task hierarchy, so these are ignored.
+    deeply_nested: bool = False
 
 
 class User:

--- a/mzla_notion/tracker/github.py
+++ b/mzla_notion/tracker/github.py
@@ -467,6 +467,25 @@ class GitHub(IssueTracker, GitHubFixups):
         if not self.dry:
             await self.endpoint(op)
 
+    def _is_deeply_nested_subissue(self, ghissue):
+        """Whether the issue is nested deeper than the single supported sub-issue layer.
+
+        The Notion sync only supports a Milestone -> Task hierarchy, so a task may be a direct
+        sub-issue of a milestone but not a sub-issue of another task. When an issue's parent is a
+        regular task (i.e. not a Milestone or Epic), it is a sub-sub-issue and we ignore it rather
+        than syncing it to Notion as an orphaned task.
+        """
+        parent = getattr(ghissue, "parent", None)
+        if not parent or not getattr(parent, "number", None):
+            return False
+
+        # Only act when the parent has a known issue type. An untyped parent is treated as valid,
+        # matching the conservative behavior in _fixup_issue_milestone_with_parent.
+        if not self._issue_type_name(parent):
+            return False
+
+        return not self._is_milestone_issue(parent) and not self._is_epic_issue(parent)
+
     async def _parse_issue(self, ghissue, sub_issues=False):
         # There isn't really a better place to put it with the current architecture. If while
         # parsing github issues we find a problem, fix it on the spot before we continue
@@ -550,6 +569,8 @@ class GitHub(IssueTracker, GitHubFixups):
 
         if ghissue.parent:
             issue.parents = [IssueRef(repo=ghissue.parent.repository.name_with_owner, id=str(ghissue.parent.number))]
+
+        issue.deeply_nested = self._is_deeply_nested_subissue(ghissue)
 
         if sub_issues:
             issue.sub_issues = [

--- a/test/test_project_github.py
+++ b/test/test_project_github.py
@@ -631,3 +631,35 @@ class GitHubProjectTest(BaseTestCase):
 
         await self.github._fixup_issue_milestone_with_parent(issue)
         self.assertIsNone(issue.parent)
+
+    def _make_parent(self, type_name):
+        return types.SimpleNamespace(
+            id="PARENT",
+            number=1,
+            issue_type=types.SimpleNamespace(name=type_name) if type_name else None,
+            repository=types.SimpleNamespace(name_with_owner="kewisch/test"),
+        )
+
+    def test_is_deeply_nested_subissue(self):
+        self.github.milestones_issue_type = "Milestone"
+        self.github.epics_issue_type = "Epic"
+
+        with self.subTest(msg="no parent"):
+            issue = types.SimpleNamespace(parent=None)
+            self.assertFalse(self.github._is_deeply_nested_subissue(issue))
+
+        with self.subTest(msg="parent is a milestone"):
+            issue = types.SimpleNamespace(parent=self._make_parent("Milestone"))
+            self.assertFalse(self.github._is_deeply_nested_subissue(issue))
+
+        with self.subTest(msg="parent is an epic"):
+            issue = types.SimpleNamespace(parent=self._make_parent("Epic"))
+            self.assertFalse(self.github._is_deeply_nested_subissue(issue))
+
+        with self.subTest(msg="untyped parent is treated as valid"):
+            issue = types.SimpleNamespace(parent=self._make_parent(None))
+            self.assertFalse(self.github._is_deeply_nested_subissue(issue))
+
+        with self.subTest(msg="parent is a regular task"):
+            issue = types.SimpleNamespace(parent=self._make_parent("Task"))
+            self.assertTrue(self.github._is_deeply_nested_subissue(issue))

--- a/test/test_project_sync.py
+++ b/test/test_project_sync.py
@@ -744,6 +744,32 @@ class ProjectSyncTest(BaseTestCase):
             },
         )
 
+    async def test_deeply_nested_subissue_ignored(self):
+        # A sub-issue of a task (sub-sub-issue) that gets picked up via the sprint board. It must
+        # not be synced to Notion since only a single Milestone -> Task layer is supported.
+        # test_task_no_parent covers that the additional-tasks pickup path does create pages, so a
+        # missing create here is proof the deeply_nested flag is what skips it.
+        nested = Issue(
+            parents=[IssueRef(repo="repo", id="234")],
+            repo="repo",
+            id="999",
+            title="Sub-sub issue",
+            description="description",
+            state="NEW",
+            created_date=datetime.datetime(2025, 4, 5, 6, 0, 0, tzinfo=datetime.timezone.utc),
+            closed_date=None,
+            priority=None,
+            url="https://example.com/repo/999",
+            deeply_nested=True,
+        )
+        tracker = IssueTestTracker(issues=[*self.issues, nested])
+        tracker.additional_tasks = [IssueRef(id="999", repo="repo")]
+
+        await self.synchronize_project(tracker)
+
+        for call in self.respx.routes["pages_create"].calls:
+            self.assertNotIn("repo/999", call.request.content.decode())
+
     async def test_task_issue_link_written_for_all_pickup_paths(self):
         tracker = IssueTestTracker(
             issues=[


### PR DESCRIPTION
## Summary

The GitHub → Notion sync only supports a single **Milestone → Task** hierarchy ("1 level of sub issues"). When an issue is a sub-issue of a *task* (a sub-sub-issue), its parent is a task rather than a milestone, so `_find_task_parents` finds no milestone and the issue lands in Notion as an **orphaned task** with no milestone relation. This is the breakage hit on [thunderbird/platform-infrastructure#384](https://github.com/thunderbird/platform-infrastructure/issues/384).

This makes the sync ignore those sub-sub-issues instead of choking on them, so milestones don't have to be manually restructured to flatten the hierarchy.

## Approach

- New `Issue.deeply_nested` flag (default `False`, so other trackers like Bugzilla are unaffected).
- `GitHub._is_deeply_nested_subissue` detects the case during issue parsing: the issue has a parent whose issue type is neither `Milestone` nor `Epic` (i.e. a regular task). An untyped parent is treated as valid, matching the conservative behavior already used in `_fixup_issue_milestone_with_parent`.
- `synchronize_single_task` skips and logs these, covering both the project sync and label sync paths.

## Notes / scope

- **Ignore-only — no GitHub mutation.** Unlike the existing hierarchy fixups, this does *not* remove any sub-issue links on GitHub. The nesting stays intact for internal tracking; it just doesn't flow to Notion.
- **Existing orphans are left untouched.** Any sub-sub-issues already created as orphan tasks in Notion won't be auto-removed; they simply stop receiving updates. Happy to make the filter self-heal (archive existing orphan pages) if that's preferred.

## Tests

- `test_is_deeply_nested_subissue` — unit coverage of the detection (no parent / milestone / epic / untyped parent / task parent).
- `test_deeply_nested_subissue_ignored` — end-to-end: a sub-sub-issue picked up via the sprint board is not written to Notion.
- Full suite + `task lint` / `task format --check` pass.